### PR TITLE
Leafbid 152 route maken voor product typen

### DIFF
--- a/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
+++ b/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
@@ -107,13 +107,33 @@ public class ProductController(IProductService productService) : ControllerBase
     /// <param name="productId"></param>
     /// <param name="userId"></param>
     /// <returns>The created product.</returns>
+    /// <exception cref="Exception">Thrown when the main product cannot be found.</exception>
     [HttpPost("/registeredCreate/{ProductId:int}")]
+    [ProducesResponseType(typeof(RegisteredProductResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RegisteredProductResponse>> CreateRegisteredProduct(
         [FromBody] CreateRegisteredProductEndpointDto productData, int productId, string userId)
     {
-        var result = 0;
+        try
+        {
+            RegisteredProduct registeredProduct = await productService.CreateProductDeliveryGuy(productData, productId, userId);
+            RegisteredProductResponse registeredProductResponse = productService.CreateRegisteredProductResponse(registeredProduct);
+            return CreatedAtAction(
+                actionName: nameof(GetProductById),
+                routeValues: new
+                {
+                    id = registeredProductResponse.Id,
+                    version = "2.0"
+                },
+                value: registeredProductResponse
+            );
+        }
+        catch (NotFoundException e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
 
-        return Ok(result);
     }
 
     /// <summary>

--- a/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
+++ b/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
@@ -101,6 +101,22 @@ public class ProductController(IProductService productService) : ControllerBase
     }
 
     /// <summary>
+    /// Create a new registered product.
+    /// </summary>
+    /// <param name="productData">The product data.</param>
+    /// <param name="productId"></param>
+    /// <param name="userId"></param>
+    /// <returns>The created product.</returns>
+    [HttpPost("/registeredCreate/{ProductId:int}")]
+    public async Task<ActionResult<RegisteredProductResponse>> CreateRegisteredProduct(
+        [FromBody] CreateRegisteredProductEndpointDto productData, int productId, string userId)
+    {
+        var result = 0;
+
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Update an existing product.
     /// </summary>
     /// <param name="id">The product ID.</param>

--- a/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
+++ b/LeafBid/LeafBidAPI/Controllers/v2/ProductController.cs
@@ -107,8 +107,9 @@ public class ProductController(IProductService productService) : ControllerBase
     /// <param name="productId"></param>
     /// <param name="userId"></param>
     /// <returns>The created product.</returns>
-    /// <exception cref="Exception">Thrown when the main product cannot be found.</exception>
+    /// <exception cref="NotFoundException">Thrown when the main product cannot be found.</exception>
     [HttpPost("/registeredCreate/{ProductId:int}")]
+    [Authorize(Roles = "Provider")]
     [ProducesResponseType(typeof(RegisteredProductResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RegisteredProductResponse>> CreateRegisteredProduct(

--- a/LeafBid/LeafBidAPI/DTOs/RegisteredProduct/CreateRegisteredProductEndpointDto.cs
+++ b/LeafBid/LeafBidAPI/DTOs/RegisteredProduct/CreateRegisteredProductEndpointDto.cs
@@ -1,0 +1,15 @@
+﻿namespace LeafBidAPI.DTOs.RegisteredProduct;
+
+public class CreateRegisteredProductEndpointDto
+{
+    /// <summary>
+    /// Data required to register a product
+    /// </summary>
+    public required string ProductId { get; set; }
+    public required decimal MinPrice { get; set; }
+    public required int Stock { get; set; }
+    public required string Region { get; set; }
+    public required DateTime HarvestedAt { get; set; }
+    public double? PotSize { get; set; }
+    public double? StemLength { get; set; }
+}

--- a/LeafBid/LeafBidAPI/Interfaces/IProductService.cs
+++ b/LeafBid/LeafBidAPI/Interfaces/IProductService.cs
@@ -49,6 +49,19 @@ public interface IProductService
     /// </exception>
     Task<Product> CreateProduct(CreateProductDto productData);
 
+    /// <summary>
+    /// Create a new registered product, for the supplier.
+    /// </summary>
+    /// <param name="registeredProductData"></param>
+    /// <param name="productId"></param>
+    /// <param name="userId"></param>
+    /// <returns>The created product for the supplier.</returns>
+    /// <exception cref="Exception">
+    /// Thrown when product cannot be created
+    /// </exception>
+    Task<RegisteredProduct> CreateProductDeliveryGuy(CreateRegisteredProductEndpointDto registeredProductData,
+        int productId, string userId);
+
 
     /// <summary>
     /// Add a user created product (this includes data that can differ per user)

--- a/LeafBid/LeafBidAPI/Services/ProductService.cs
+++ b/LeafBid/LeafBidAPI/Services/ProductService.cs
@@ -123,22 +123,35 @@ public class ProductService(
             throw new NotFoundException("Product not found");
         }
         User? user = await userManager.FindByIdAsync(userId);
-
-        RegisteredProduct registeredProduct = new()
+        if (user == null)
         {
-            ProductId = productId,
-            MinPrice = registeredProductData.MinPrice,
-            Stock = registeredProductData.Stock,
-            Region = registeredProductData.Region,
-            HarvestedAt = registeredProductData.HarvestedAt,
-            CompanyId = user.CompanyId.Value,
-            UserId = userId
-        };
+            throw new NotFoundException("User not found");
+        }
 
-        context.RegisteredProducts.Add(registeredProduct);
-        await context.SaveChangesAsync();
+        if (user.CompanyId != null)
+        {
+            RegisteredProduct registeredProduct = new()
+            {
+                ProductId = productId,
+                MinPrice = registeredProductData.MinPrice,
+                Stock = registeredProductData.Stock,
+                Region = registeredProductData.Region,
+                HarvestedAt = registeredProductData.HarvestedAt,
+                StemLength = registeredProductData.StemLength,
+                PotSize = registeredProductData.PotSize,
+                CompanyId = user.CompanyId.Value,
+                UserId = userId
+            };
 
-        return registeredProduct;
+            context.RegisteredProducts.Add(registeredProduct);
+            await context.SaveChangesAsync();
+
+            return registeredProduct;
+        }
+        else
+        {
+            throw new NotFoundException("User is not a company");
+        }
     }
 
     public async Task<RegisteredProduct> AddProduct(int productId, CreateRegisteredProductDto registeredProductData)

--- a/LeafBid/LeafBidAPI/Services/ProductService.cs
+++ b/LeafBid/LeafBidAPI/Services/ProductService.cs
@@ -122,6 +122,7 @@ public class ProductService(
         {
             throw new NotFoundException("Product not found");
         }
+        
         User? user = await userManager.FindByIdAsync(userId);
         if (user == null)
         {

--- a/LeafBid/LeafBidAPI/Services/ProductService.cs
+++ b/LeafBid/LeafBidAPI/Services/ProductService.cs
@@ -115,6 +115,32 @@ public class ProductService(
         return product;
     }
 
+    public async Task<RegisteredProduct> CreateProductDeliveryGuy(CreateRegisteredProductEndpointDto registeredProductData, int productId, string userId)
+    {
+        Product? product = await context.Products.FirstOrDefaultAsync(p => p.Id == productId);
+        if (product == null)
+        {
+            throw new NotFoundException("Product not found");
+        }
+        User? user = await userManager.FindByIdAsync(userId);
+
+        RegisteredProduct registeredProduct = new()
+        {
+            ProductId = productId,
+            MinPrice = registeredProductData.MinPrice,
+            Stock = registeredProductData.Stock,
+            Region = registeredProductData.Region,
+            HarvestedAt = registeredProductData.HarvestedAt,
+            CompanyId = user.CompanyId.Value,
+            UserId = userId
+        };
+
+        context.RegisteredProducts.Add(registeredProduct);
+        await context.SaveChangesAsync();
+
+        return registeredProduct;
+    }
+
     public async Task<RegisteredProduct> AddProduct(int productId, CreateRegisteredProductDto registeredProductData)
     {
         User? user = await userManager.FindByIdAsync(registeredProductData.UserId);

--- a/LeafBid/LeafBidAPI/Services/ProductService.cs
+++ b/LeafBid/LeafBidAPI/Services/ProductService.cs
@@ -129,30 +129,28 @@ public class ProductService(
             throw new NotFoundException("User not found");
         }
 
-        if (user.CompanyId != null)
+        if (user.CompanyId == null)
         {
-            RegisteredProduct registeredProduct = new()
-            {
-                ProductId = productId,
-                MinPrice = registeredProductData.MinPrice,
-                Stock = registeredProductData.Stock,
-                Region = registeredProductData.Region,
-                HarvestedAt = registeredProductData.HarvestedAt,
-                StemLength = registeredProductData.StemLength,
-                PotSize = registeredProductData.PotSize,
-                CompanyId = user.CompanyId.Value,
-                UserId = userId
-            };
-
-            context.RegisteredProducts.Add(registeredProduct);
-            await context.SaveChangesAsync();
-
-            return registeredProduct;
+            throw new NotFoundException("User is not part of a company");
         }
-        else
+        
+        RegisteredProduct registeredProduct = new()
         {
-            throw new NotFoundException("User is not a company");
-        }
+            ProductId = productId,
+            MinPrice = registeredProductData.MinPrice,
+            Stock = registeredProductData.Stock,
+            Region = registeredProductData.Region,
+            HarvestedAt = registeredProductData.HarvestedAt,
+            StemLength = registeredProductData.StemLength,
+            PotSize = registeredProductData.PotSize,
+            CompanyId = user.CompanyId.Value,
+            UserId = userId
+        };
+
+        context.RegisteredProducts.Add(registeredProduct);
+        await context.SaveChangesAsync();
+
+        return registeredProduct;
     }
 
     public async Task<RegisteredProduct> AddProduct(int productId, CreateRegisteredProductDto registeredProductData)


### PR DESCRIPTION
This pull request introduces functionality for creating a new registered product associated with a supplier ("delivery guy"). It adds a new API endpoint, supporting DTO, service method, and interface contract, ensuring that only users linked to a company can register products. The changes are grouped as follows:

**API and Endpoint Additions:**

* Added a new POST endpoint `CreateRegisteredProduct` in `ProductController` to allow creation of a registered product for a supplier, returning appropriate responses and error handling for missing products or users.

**Data Transfer Object (DTO):**

* Introduced `CreateRegisteredProductEndpointDto` to encapsulate the data required to register a product, including product details and optional measurements.

**Service and Business Logic:**

* Implemented `CreateProductDeliveryGuy` in `ProductService` to handle the business logic for creating a registered product, including validation for product existence, user existence, and company association. Throws `NotFoundException` in case of missing entities or invalid user type.
* Updated the `IProductService` interface to define the new `CreateProductDeliveryGuy` method, documenting its parameters and exceptions.